### PR TITLE
fix: `delete` will now delete the key-value (412 fix)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,6 @@ module.exports = {
     'consistent-return': 'off',
     'max-classes-per-file': 'off',
     'default-param-last': 'off',
-    camelcase: 'off',
+    // camelcase: 'off',
   },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "RESTful API",
   "main": "src/server.js",
   "author": "Siddharth Rawat <rawat.sid@northeastern.edu>",


### PR DESCRIPTION
The 412 Precondition Failed condition `header` filter now allows client to delete the object irrespective of the conditional delete.